### PR TITLE
Xpath filter 2.0 signature removal support

### DIFF
--- a/signxml/algorithms.py
+++ b/signxml/algorithms.py
@@ -158,6 +158,11 @@ class CanonicalizationMethod(InvalidInputErrorMixin, Enum):
     # While it is supported by lxml, it's not in general use and not supported by SignXML
 
 
+class TransformAlgorithm(Enum):
+    dsig_filter2 = "http://www.w3.org/2002/06/xmldsig-filter2"
+
+
+
 digest_algorithm_implementations: Dict[Union[DigestAlgorithm, SignatureMethod], Type[hashes.HashAlgorithm]] = {
     DigestAlgorithm.SHA1: hashes.SHA1,
     DigestAlgorithm.SHA224: hashes.SHA224,

--- a/signxml/algorithms.py
+++ b/signxml/algorithms.py
@@ -162,7 +162,6 @@ class TransformAlgorithm(Enum):
     dsig_filter2 = "http://www.w3.org/2002/06/xmldsig-filter2"
 
 
-
 digest_algorithm_implementations: Dict[Union[DigestAlgorithm, SignatureMethod], Type[hashes.HashAlgorithm]] = {
     DigestAlgorithm.SHA1: hashes.SHA1,
     DigestAlgorithm.SHA224: hashes.SHA224,

--- a/signxml/util/__init__.py
+++ b/signxml/util/__init__.py
@@ -30,6 +30,7 @@ namespaces = Namespace(
     ds="http://www.w3.org/2000/09/xmldsig#",
     dsig11="http://www.w3.org/2009/xmldsig11#",
     dsig2="http://www.w3.org/2010/xmldsig2#",
+    dsig_filter2="http://www.w3.org/2002/06/xmldsig-filter2",
     ec="http://www.w3.org/2001/10/xml-exc-c14n#",
     dsig_more="http://www.w3.org/2001/04/xmldsig-more#",
     xenc="http://www.w3.org/2001/04/xmlenc#",

--- a/signxml/verifier.py
+++ b/signxml/verifier.py
@@ -201,7 +201,7 @@ class XMLVerifier(XMLSignatureProcessor):
             if algorithm == SignatureConstructionMethod.enveloped.value:
                 _remove_sig(signature, idempotent=True)
             if algorithm == TransformAlgorithm.dsig_filter2.value:
-                transform_xpath = self._find(transform, f"dsig_filter2:XPath")
+                transform_xpath = self._find(transform, "dsig_filter2:XPath")
                 if transform_xpath is not None and transform_xpath.get("Filter") == "subtract":
                     elements = payload.xpath(transform_xpath.text, namespaces=namespaces)
                     for element in elements:

--- a/signxml/verifier.py
+++ b/signxml/verifier.py
@@ -201,8 +201,10 @@ class XMLVerifier(XMLSignatureProcessor):
                 _remove_sig(signature, idempotent=True)
             if algorithm == TransformAlgorithm.dsig_filter2.value:
                 transform_xpath = self._find(transform, f"dsig_filter2:XPath")
-                if transform_xpath is not None and transform_xpath.get("Filter") == "subtract" and signature == payload.xpath(transform_xpath.text, namespaces=namespaces)[0]:
-                    _remove_sig(signature, idempotent=True)
+                if transform_xpath is not None and transform_xpath.get("Filter") == "subtract":
+                    elements = payload.xpath(transform_xpath.text, namespaces=namespaces)
+                    for element in elements:
+                        _remove_sig(element, idempotent=True)
 
         for transform in transforms:
             if transform.get("Algorithm") == "http://www.w3.org/2000/09/xmldsig#base64":

--- a/signxml/verifier.py
+++ b/signxml/verifier.py
@@ -200,7 +200,7 @@ class XMLVerifier(XMLSignatureProcessor):
             if algorithm == SignatureConstructionMethod.enveloped.value:
                 _remove_sig(signature, idempotent=True)
             if algorithm == TransformAlgorithm.dsig_filter2.value:
-                transform_xpath = self._find(transform, f"{namespaces.dsig_filter2}:XPath")
+                transform_xpath = self._find(transform, f"dsig_filter2:XPath")
                 if transform_xpath is not None and transform_xpath.get("Filter") == "subtract" and signature == payload.xpath(transform_xpath.text, namespaces=namespaces)[0]:
                     _remove_sig(signature, idempotent=True)
 

--- a/signxml/verifier.py
+++ b/signxml/verifier.py
@@ -201,7 +201,7 @@ class XMLVerifier(XMLSignatureProcessor):
                 _remove_sig(signature, idempotent=True)
             if algorithm == TransformAlgorithm.dsig_filter2.value:
                 transform_xpath = self._find(transform, f"{namespaces.dsig_filter2}:XPath")
-                if transform_xpath and transform_xpath.get("Filter") == "subtract" and signature == payload.xpath(transform_xpath.text, namespaces=namespaces)[0]:
+                if transform_xpath is not None and transform_xpath.get("Filter") == "subtract" and signature == payload.xpath(transform_xpath.text, namespaces=namespaces)[0]:
                     _remove_sig(signature, idempotent=True)
 
         for transform in transforms:

--- a/signxml/verifier.py
+++ b/signxml/verifier.py
@@ -17,7 +17,8 @@ from .algorithms import (
     DigestAlgorithm,
     SignatureConstructionMethod,
     SignatureMethod,
-    digest_algorithm_implementations, TransformAlgorithm,
+    TransformAlgorithm,
+    digest_algorithm_implementations,
 )
 from .exceptions import InvalidCertificate, InvalidDigest, InvalidInput, InvalidSignature
 from .processor import XMLSignatureProcessor

--- a/test/example-xpath-filter.xml
+++ b/test/example-xpath-filter.xml
@@ -1,0 +1,47 @@
+<data>
+    <!-- This comment is very important! -->
+    <country name="Liechtenstein">
+        <rank>1</rank>
+        <year>2008</year>
+        <gdppc>141100</gdppc>
+        <neighbor name="Austria" direction="E"/>
+        <neighbor name="Switzerland" direction="W"/>
+    </country>
+    <country name="Singapore">
+        <rank>4</rank>
+        <year>2011</year>
+        <gdppc>59900</gdppc>
+        <neighbor name="Malaysia" direction="N"/>
+    </country>
+    <country name="Panama">
+        <rank>68</rank>
+        <year>2011</year>
+        <gdppc>13600</gdppc>
+        <neighbor name="Costa Rica" direction="W"/>
+        <neighbor name="Colombia" direction="E"/>
+    </country>
+<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2006/12/xml-c14n11"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><ds:Reference URI=""><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2002/06/xmldsig-filter2"><XPath xmlns="http://www.w3.org/2002/06/xmldsig-filter2" Filter="subtract">/descendant::ds:Signature</XPath></ds:Transform><ds:Transform Algorithm="http://www.w3.org/2006/12/xml-c14n11"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><ds:DigestValue>phz8KnRySaYxGRtVaEG1/XPY+8JRkEcl0HIPl8ySSfs=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>ZCWdhmqIm9qELuOBY32xbWioYAhIpfga1naOW7XkzAszIqw8BzDCsk7NeSQhQaDqfNV5G3Q0C6RHYeVaxtCuASBczmFcAGBjJdaLo2QTCVMo/AyEk3ndQmLRxbnrI91WB0pW3+tpj1fs0k7Pg2dqo/hWhkOxI3vxbtMDcGFfrS8=</ds:SignatureValue><ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIIEUTCCA7qgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBrDELMAkGA1UEBhMCVVMx
+CzAJBgNVBAgTAkNBMRUwEwYDVQQHEwxNb3VudGFpblZpZXcxETAPBgNVBAoTCERO
+QW5leHVzMRMwEQYDVQQLEwpPcGVyYXRpb25zMRQwEgYDVQQDEwtETkFuZXh1cyBD
+QTEZMBcGA1UEKRMQRE5BbmV4dXNQbGF0Zm9ybTEgMB4GCSqGSIb3DQEJARYRaW5m
+b0BkbmFuZXh1cy5jb20wHhcNMTQwOTE1MDIwNjM3WhcNMjQwOTEyMDIwNjM3WjCB
+rjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRUwEwYDVQQHEwxNb3VudGFpblZp
+ZXcxETAPBgNVBAoTCEROQW5leHVzMRMwEQYDVQQLEwpPcGVyYXRpb25zMRYwFAYD
+VQQDFA0qLmV4YW1wbGUuY29tMRkwFwYDVQQpExBETkFuZXh1c1BsYXRmb3JtMSAw
+HgYJKoZIhvcNAQkBFhFpbmZvQGRuYW5leHVzLmNvbTCBnzANBgkqhkiG9w0BAQEF
+AAOBjQAwgYkCgYEAvbCY1tXqnjH8gFfY8FDcBM4xXV43NOPp1eJ7Ke+z0PS5m8AO
+w2i75LwtPx0Mn7itLpfB6x95kVkQbS1PXb/C/8FPdBqMLZGChzO+ZW7i5Nl6Ckdf
+5QqumJcOObBqs0N1DQ/765gWZaUy2Yycl/xYlpY43R4m9zaDdirz+jGrsQkCAwEA
+AaOCAX0wggF5MAkGA1UdEwQCMAAwEQYJYIZIAYb4QgEBBAQDAgZAMDQGCWCGSAGG
++EIBDQQnFiVFYXN5LVJTQSBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0G
+A1UdDgQWBBRlDO8LQtZo/K38JQ2RLrh6uL43NTCB4QYDVR0jBIHZMIHWgBSvoZrl
+dd3E70KF+jxbiTuu96w/lqGBsqSBrzCBrDELMAkGA1UEBhMCVVMxCzAJBgNVBAgT
+AkNBMRUwEwYDVQQHEwxNb3VudGFpblZpZXcxETAPBgNVBAoTCEROQW5leHVzMRMw
+EQYDVQQLEwpPcGVyYXRpb25zMRQwEgYDVQQDEwtETkFuZXh1cyBDQTEZMBcGA1UE
+KRMQRE5BbmV4dXNQbGF0Zm9ybTEgMB4GCSqGSIb3DQEJARYRaW5mb0BkbmFuZXh1
+cy5jb22CCQCJA4llz8RTkTATBgNVHSUEDDAKBggrBgEFBQcDATALBgNVHQ8EBAMC
+BaAwDQYJKoZIhvcNAQEFBQADgYEAAqt0uP2c9VZY66apLY/vYYM2vCUWQqB0BYL0
+PCI5OeEHzGOQF8DbD4fiqNHY2NTRO4M/n+gMve6vquOCBegs/fJIf5ZoWjLaUZRm
+5PNOCO7zXt7VG3eGtq1MFfMiFD6bv7bAJCnnjtcxt6me+bxY0/QQkldxNE5pLam+
+UiqB4gc=
+</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature></data>

--- a/test/test.py
+++ b/test/test.py
@@ -97,6 +97,15 @@ class TestVerifyXML(unittest.TestCase, LoadExampleKeys):
             expect_references=2,
         )
 
+    def test_example_xpath_filter(self):
+        with open(os.path.join(os.path.dirname(__file__), "example.pem")) as fh:
+            cert = fh.read()
+        example_file = os.path.join(os.path.dirname(__file__), "example-xpath-filter.xml")
+        XMLVerifier().verify(
+            data=etree.parse(example_file),
+            x509_cert=cert,
+        )
+
 
 class TestSignXML(unittest.TestCase, LoadExampleKeys):
     def setUp(self):


### PR DESCRIPTION
## Changes:
* Added support for XPath filter way of Enveloped Signature transform

**Note:** Only implements a subset of [XML-Signature XPath Filter 2.0](https://www.w3.org/TR/xmldsig-filter2/) that deals with signature removal. It accomplishes this by identifying the transform algorithm correctly, checking if the `Filter` is a `subtract` filter and using the XPath in the Transform to extract an element to compare with the signature. If they match, it is deducted that it's the signature that the Transform is subtract filtering and thus the signature is removed. More details can be found [here](https://www.w3.org/TR/xmldsig-core2/#sec-EnvelopedSignature).